### PR TITLE
Fix headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-gitart-generator
-================
+# gitart-generator
 
 Your contributions chart is all empty and dull? Use it as a canvas and draw something beautiful!
 
-##How do I?##
+## How do I?
 
 1. Create a new repo on github.
 2. Draw your image in the form of ascii art.
 3. Let `gitart.sh` do the magic!
 
-##Input file##
+## Input file
 
 The magic needs some input. Define it in a text file:  
 - Lines 1-7: Your Art. Any non-space character is considered a commit (be careful with tabs!).  
@@ -21,7 +20,7 @@ The magic needs some input. Define it in a text file:
 
 Example input file is provided.
 
-##Warnings##
+## Warnings
 
 - This script messes with your system time and therefore requires root privileges. Use at your own risk.
 - An ugly timezone hack: time is set to 12:00 AM when shifting dates.


### PR DESCRIPTION
The hash symbol requires a space after it for correct formatting.

Before: 

![image](https://user-images.githubusercontent.com/24862378/32691665-1ef70c02-c703-11e7-9e9f-31ec5e35d1c3.png)

After:

![image](https://user-images.githubusercontent.com/24862378/32691686-5d8f505a-c703-11e7-919d-11ac801f6311.png)
